### PR TITLE
Update Nomad to 0.8.7

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,5 +13,5 @@ builds:
       - 6
 
     env:
-      - CGO_ENABLED=0
-      - CC=arm-linux-gnueabihf-gcc
+      - CGO_ENABLED=1
+      - CC=arm-linux-gnueabi-gcc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM amd64/debian:9 as builder
+
+ENV go_version=go1.12.2.linux-amd64
+ARG nomad_version="v0.8.7"
+ENV GOPATH=/root/go
+ENV PATH="$PATH:/usr/local/go/bin:/root/go/bin"
+
+RUN apt-get update \
+  && apt-get install -y sudo
+
+COPY install.sh /install.sh
+RUN bash /install.sh
+
+COPY .goreleaser.yml "${GOPATH}/src/github.com/hashicorp/nomad/.goreleaser.yml"
+COPY build.sh /build.sh
+RUN bash /build.sh
+
+FROM alpine:latest
+COPY --from=builder \
+  /root/go/src/github.com/hashicorp/nomad/dist/linux_arm_6/nomad \
+  /usr/bin/nomad

--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
 # nomad-arm6l
 [![Build Status](https://travis-ci.org/nicholasjackson/nomad-arm6l.svg?branch=master)](https://travis-ci.org/nicholasjackson/nomad-arm6l)
 
-Build of Nomad for Raspberry Pi, currently statically links and disables CGO
+Build of Nomad for Raspberry Pi statically linked
+
+### Automated build
+
+This uses Scaleway to provide an ARMv7 host automatically and compile `nomad`.
+
+### Local build: Cross-compilation
+
+This uses a Docker image to cross-compile `nomad`.
+
+To get the binary to the host, run the following command:
+
+```sh
+docker build --pull -t nomad-arm6l .
+docker run --rm nomad-arm6l cat /usr/bin/nomad > nomad
+```
+
+It is possible to compile a new version as well, using the following command:
+
+```sh
+docker build --pull --build-arg nomad_version="master" -t nomad-arm6l .
+docker run --rm nomad-arm6l cat /usr/bin/nomad > nomad
+```

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
-go get github.com/goreleaser/goreleaser
-git clone https://github.com/nicholasjackson/nomad-arm6l.git
-
-cp ./nomad-arm6l/.goreleaser.yml $GOPATH/src/github.com/hashicorp/nomad
+if ! [[ -f "$GOPATH/src/github.com/hashicorp/nomad/.goreleaser.yml" ]]; then
+    git clone https://github.com/nicholasjackson/nomad-arm6l.git
+    cp ./nomad-arm6l/.goreleaser.yml $GOPATH/src/github.com/hashicorp/nomad
+fi
 
 cd $GOPATH/src/github.com/hashicorp/nomad
-goreleaser --skip-validate --rm-dist --skip-publish  
+goreleaser --skip-validate --rm-dist --skip-publish

--- a/install.sh
+++ b/install.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get install -y git build-essential curl libc6-armel-cross libc6-dev-armel-cross
+sudo apt-get install -y git build-essential curl libc6-armel-cross libc6-dev-armel-cross gcc-arm-linux-gnueabi
 
-curl -L -o ~/${go_version}.tar.gz https://dl.google.com/go/${go_version}.tar.gz 
+curl -L -o ~/${go_version}.tar.gz https://dl.google.com/go/${go_version}.tar.gz
 tar -C /usr/local -xzf ~/${go_version}.tar.gz
 mkdir /root/go
-
-mkdir /root/gcc_tools
-git clone https://github.com/raspberrypi/tools.git --depth 1 /root/gcc_tools
 
 echo "GOPATH=/root/go" >> /root/.ssh/environment
 echo "PATH=$PATH:/usr/local/go/bin:/root/go/bin" >> /root/.ssh/environment
 echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config
 
-mkdir -p /root/go/src/github.com/hashicorp
-git clone --branch ${nomad_version} https://github.com/hashicorp/nomad.git /root/go/src/github.com/hashicorp/nomad
+mkdir -p ${GOPATH}/src/github.com/hashicorp
+git clone --branch ${nomad_version} https://github.com/hashicorp/nomad.git ${GOPATH}/src/github.com/hashicorp/nomad
 
-sudo systemctl restart sshd
+go get github.com/goreleaser/goreleaser

--- a/terraform.tf
+++ b/terraform.tf
@@ -62,6 +62,7 @@ resource "scaleway_server" "build" {
     inline = [
       "chmod +x /tmp/script.sh",
       "/tmp/script.sh args",
+      "sudo systemctl restart sshd",
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "ssh_key" {
 }
 
 variable "go_version" {
-  default = "1.9.3"
+  default = "1.12.2"
 }
 
 variable "nomad_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,5 +8,5 @@ variable "go_version" {
 
 variable "nomad_version" {
   description = "Nomad tag or branch to build"
-  default     = "v0.7.1"
+  default     = "v0.8.7"
 }


### PR DESCRIPTION
Thanks for the project, it helped me to get to know better what is required when compiling Nomad.

This commit provides a cross compilation Docker image which compiles the
project using the same scripts as it is used on the remote machine.

With the cross compilation image it is possible to test it locally.

We introduced a new compiler on the build step, so we are capable of
using `cgo` during compilation, as it was [reported] to be required for
newer versions of Nomad.

This has been tested running Docker from Mac, and sending the output to
a Pi Zero W using `scp`. The binary starts up, but there were no further
tests on how the scheduler behaves at this moment.

This also has been tested compiling Nomad `0.8.7` and `master`
(currently `0.9.0-dev`), using the `CGO_ENABLED` and the correct
gcc `armv6l` compiler.

[reported]: hashicorp/nomad#5337

Closes #1 